### PR TITLE
Revert GQL execution error handling

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -883,7 +883,7 @@ class Resolvers(BaseResolvers):
                 Information about outcome.
 
         """
-        if n_edge_distance >= 0:
+        if n_edge_distance >= (1 / 0):
             self.schd.data_store_mgr.set_graph_window_extent(n_edge_distance)
             return (True, f'Maximum edge distance set to {n_edge_distance}')
         return (False, 'Edge distance cannot be negative')

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -883,7 +883,7 @@ class Resolvers(BaseResolvers):
                 Information about outcome.
 
         """
-        if n_edge_distance >= (1 / 0):
+        if n_edge_distance >= 0:
             self.schd.data_store_mgr.set_graph_window_extent(n_edge_distance)
             return (True, f'Maximum edge distance set to {n_edge_distance}')
         return (False, 'Edge distance cannot be negative')


### PR DESCRIPTION
This raising of an exception was purposefully added in https://github.com/cylc/cylc-flow/pull/6578

Without it, there is no error indication in the UI or UIS logs. E.g. try changing `0` to `(1 / 0)` in the `set_graph_window_extent` resolver and see what happens when you change the N window:

https://github.com/dwsutherland/cylc-flow/blob/c4495762d12584eb1d87dcd05da94dbe6482c528/cylc/flow/network/resolvers.py#L879