### PR TITLE
data store: state totals

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -763,7 +763,7 @@ class Workflow(ObjectType):
     )
     state_totals = GenericScalar(
         resolver=resolve_state_totals,
-        description='The number of tasks in each state as a JSON object.',
+        description='The number of n=0 tasks in each state as a JSON object.',
     )
     latest_state_tasks = GenericScalar(
         states=graphene.List(


### PR DESCRIPTION
@dwsutherland, small change to the PR:

* Family state totals now always reflect the n=0 irrespective of whether the family is itself in the n=0 window or not.
* Replace state counter with a state set.